### PR TITLE
download url hot fix

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -35,10 +35,14 @@ class play ($version = "1.2.3") {
 	
 	$play_version = $version
 	$play_path = "/opt/play-${play_version}"
+	$download_url = $play_version ? {
+	  '2.1.0' => "http://downloads.typesafe.com/play/${play_version}/play-${play_version}.zip",
+	  default => "http://downloads.typesafe.com/releases/play-${play_version}.zip",
+	}
 	
 	notice("Installing Play ${play_version}")
 	exec { "download-play-framework":                                                                                                                     
-        command => "wget http://download.playframework.org/releases/play-${play_version}.zip",                                                         
+        command => "wget $download_url",                                                         
         cwd     => "/tmp",
         creates => "/tmp/play-${play_version}.zip",                                                              
 		unless  => "test -d $play_path",

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,6 +13,7 @@
 # *version* : the Play version to install
 #
 # Requires:
+# wget puppet module https://github.com/EslamElHusseiny/puppet-wget
 # A proper java installation and JAVA_HOME set
 # Sample Usage:
 #  include play
@@ -32,7 +33,9 @@
 #  }
 #
 class play ($version = "1.2.3") {
-	
+
+	include wget
+
 	$play_version = $version
 	$play_path = "/opt/play-${play_version}"
 	$download_url = $play_version ? {
@@ -41,19 +44,17 @@ class play ($version = "1.2.3") {
 	}
 	
 	notice("Installing Play ${play_version}")
-	exec { "download-play-framework":                                                                                                                     
-        command => "wget $download_url",                                                         
-        cwd     => "/tmp",
-        creates => "/tmp/play-${play_version}.zip",                                                              
-		unless  => "test -d $play_path",
-		require => [Package["wget"]]
-    }
+        wget::fetch{'download-play-framework':
+          source      => "$play_url",
+          destination => "/tmp/play-${play_version}.zip",
+          timeout     => 0,
+        }
 
 	exec {"unzip-play-framework":
 	    cwd     => "/opt",
         command => "/usr/bin/unzip /tmp/play-${play_version}.zip",
         unless  => "test -d $play_path",
-        require => [ Package["unzip"], Exec["download-play-framework"] ],
+        require => [ Package["unzip"], Wget::Fetch["download-play-framework"] ],
 	}
 	
 	file { "$play_path/play":
@@ -63,10 +64,5 @@ class play ($version = "1.2.3") {
 		require => [Exec["unzip-play-framework"]]
 	}
 	
-	if !defined(Package['unzip']){ package{"unzip": ensure => installed} }
-	
-	package {
-	    "wget":
-	        ensure => installed
-	}	
+	if !defined(Package['unzip']){ package{"unzip": ensure => installed} }	
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -63,10 +63,7 @@ class play ($version = "1.2.3") {
 		require => [Exec["unzip-play-framework"]]
 	}
 	
-	package {
-	    "unzip":
-	        ensure => installed
-	}
+	if !defined(Package['unzip']){ package{"unzip": ensure => installed} }
 	
 	package {
 	    "wget":


### PR DESCRIPTION
by release of v2.1.0 download url changes as following 

v2.1.0 => http://downloads.typesafe.com/play/2.1.0/play-2.1.0.zip
older versions e.g. 2.0.4 => http://downloads.typesafe.com/releases/play-2.0.4.zip

so i variablized download url depending on version 
