### PR TITLE
Fixed whitespace.

### DIFF
--- a/manifests/application.pp
+++ b/manifests/application.pp
@@ -10,10 +10,13 @@
 #  mandatory, absolute path of the application.
 #
 # [*sync*]
-#  enable dependency sync before starting the application. Accepted values are true|false (false by default).
+#  enable dependency sync before starting the application.
+#  Accepted values are true|false (false by default).
 #
 # [*ensure*]
-#  checks that the application is running (stopped), starts (stopped) it if needed. Accepted value are running|stopped. (running by default)
+#  checks that the application is running (stopped),
+#  starts (stopped) it if needed. Accepted value are
+#  running|stopped. (running by default)
 #
 # [*frameworkId*]
 #  the framework id to start the application (no framework id by default)
@@ -51,16 +54,22 @@
 #     javaOptions => -Xx1024m
 #   }
 #
-define play::application($path, $sync = false, $ensure = running, $frameworkId = "", $javaOptions = "") {
+define play::application(
+  $path,
+  $sync        = false,
+  $ensure      = running,
+  $frameworkId = '',
+  $javaOptions = ''
+) {
   include play
 
-  $syncArgument = ""
+  $syncArgument = ''
   if $sync {
-    $syncArgument = "--sync"
+    $syncArgument = '--sync'
   }
 
-  $frameworkArgument = ""
-  if $frameworkId != "" {
+  $frameworkArgument = ''
+  if $frameworkId != '' {
     $frameworkArgument = "--%${frameworkId}"
   }
 
@@ -68,21 +77,21 @@ define play::application($path, $sync = false, $ensure = running, $frameworkId =
     notice("Running play application from ${path}")
     exec { "play-resolve-dependencies-${path}":
       command => "${play::play_path}/play dependencies ${syncArgument} ${path}",
-      cwd     => "${path}",
-      unless  => "test -f $path/server.pid",
+      cwd     => $path,
+      unless  => "test -f ${path}/server.pid",
     }
 
     exec { "start-play-application-${path}":
       command => "${play::play_path}/play start ${path} ${frameworkArgument} ${javaOptions}",
-      cwd     => "${path}",
-      unless  => "test -f $path/server.pid",
+      cwd     => $path,
+      unless  => "test -f ${path}/server.pid",
     }
   } else {
     notice("Stopping play application from ${path}")
     exec { "stop-play-application-${path}":
       command => "${play::play_path}/play stop ${path}",
-      cwd     => "${path}",
-      onlyif  => "test -f $path/server.pid",
+      cwd     => $path,
+      onlyif  => "test -f ${path}/server.pid",
     }
   }
 }

--- a/manifests/application.pp
+++ b/manifests/application.pp
@@ -6,7 +6,7 @@
 #
 # == Parameters
 #
-# [*path*] 
+# [*path*]
 #  mandatory, absolute path of the application.
 #
 # [*sync*]
@@ -53,7 +53,7 @@
 #
 define play::application($path, $sync = false, $ensure = running, $frameworkId = "", $javaOptions = "") {
   include play
- 
+
   $syncArgument = ""
   if $sync {
    	$syncArgument = "--sync"
@@ -66,21 +66,21 @@ define play::application($path, $sync = false, $ensure = running, $frameworkId =
 
   if $ensure == running {
 	  notice("Running play application from ${path}")
-	  exec { "play-resolve-dependencies-${path}":                                                                                                                     
-	      command => "${play::play_path}/play dependencies ${syncArgument} ${path}",                                                         
+	  exec { "play-resolve-dependencies-${path}":
+	      command => "${play::play_path}/play dependencies ${syncArgument} ${path}",
 	      cwd     => "${path}",
 	      unless  => "test -f $path/server.pid",
-	  }  
+	  }
 
-	  exec { "start-play-application-${path}":                                                                                                                     
+	  exec { "start-play-application-${path}":
 	      command => "${play::play_path}/play start ${path} ${frameworkArgument} ${javaOptions}",
 	      cwd     => "${path}",
 	      unless  => "test -f $path/server.pid",
 	  }
 	} else {
 		notice("Stopping play application from ${path}")
-		exec { "stop-play-application-${path}":                                                                                                                     
-	      command => "${play::play_path}/play stop ${path}",                                                         
+		exec { "stop-play-application-${path}":
+	      command => "${play::play_path}/play stop ${path}",
 	      cwd     => "${path}",
 	      onlyif  => "test -f $path/server.pid",
 	  }

--- a/manifests/application.pp
+++ b/manifests/application.pp
@@ -24,29 +24,29 @@
 # == Examples
 #
 #   play::application { "bilderverwaltung" :
-#	  path    => "/home/clement/demo/bilderverwaltung",
+#     path    => "/home/clement/demo/bilderverwaltung",
 #     require => [Jdk6["Java6SDK"], Play::Module["mongodb module"]]
 #   }
 #
 #   play::application { "bilderverwaltung" :
 #     ensure  => running,
-#	  path    => "/home/clement/demo/bilderverwaltung",
+#     path    => "/home/clement/demo/bilderverwaltung",
 #   }
 #
 #   play::application { "bilderverwaltung" :
 #     ensure  => stopped,
-#	  path    => "/home/clement/demo/bilderverwaltung",
+#     path    => "/home/clement/demo/bilderverwaltung",
 #   }
 #
 #   play::application { "bilderverwaltung" :
 #     ensure  => running,
 #     sync    => true,
-#	  path    => "/home/clement/demo/bilderverwaltung",
+#     path    => "/home/clement/demo/bilderverwaltung",
 #   }
 #
 #   play::application { "bilderverwaltung" :
-#     ensure  => running,
-#	  path    => "/home/clement/demo/bilderverwaltung",
+#     ensure      => running,
+#     path        => "/home/clement/demo/bilderverwaltung",
 #     frameworkId => "prod",
 #     javaOptions => -Xx1024m
 #   }
@@ -56,33 +56,33 @@ define play::application($path, $sync = false, $ensure = running, $frameworkId =
 
   $syncArgument = ""
   if $sync {
-   	$syncArgument = "--sync"
+    $syncArgument = "--sync"
   }
 
   $frameworkArgument = ""
   if $frameworkId != "" {
-	$frameworkArgument = "--%${frameworkId}"
+    $frameworkArgument = "--%${frameworkId}"
   }
 
   if $ensure == running {
-	  notice("Running play application from ${path}")
-	  exec { "play-resolve-dependencies-${path}":
-	      command => "${play::play_path}/play dependencies ${syncArgument} ${path}",
-	      cwd     => "${path}",
-	      unless  => "test -f $path/server.pid",
-	  }
+    notice("Running play application from ${path}")
+    exec { "play-resolve-dependencies-${path}":
+      command => "${play::play_path}/play dependencies ${syncArgument} ${path}",
+      cwd     => "${path}",
+      unless  => "test -f $path/server.pid",
+    }
 
-	  exec { "start-play-application-${path}":
-	      command => "${play::play_path}/play start ${path} ${frameworkArgument} ${javaOptions}",
-	      cwd     => "${path}",
-	      unless  => "test -f $path/server.pid",
-	  }
-	} else {
-		notice("Stopping play application from ${path}")
-		exec { "stop-play-application-${path}":
-	      command => "${play::play_path}/play stop ${path}",
-	      cwd     => "${path}",
-	      onlyif  => "test -f $path/server.pid",
-	  }
-	}	
+    exec { "start-play-application-${path}":
+      command => "${play::play_path}/play start ${path} ${frameworkArgument} ${javaOptions}",
+      cwd     => "${path}",
+      unless  => "test -f $path/server.pid",
+    }
+  } else {
+    notice("Stopping play application from ${path}")
+    exec { "stop-play-application-${path}":
+      command => "${play::play_path}/play stop ${path}",
+      cwd     => "${path}",
+      onlyif  => "test -f $path/server.pid",
+    }
+  }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,71 +21,73 @@
 #    user    => "appuser"
 #  }
 #  play::module {"mongodb module" :
-#   module  => "mongo-1.3",
-# require => [Class["play"], Class["mongodb"]]
+#    module  => "mongo-1.3",
+#    require => [Class["play"], Class["mongodb"]]
 #  }
 #
 #  play::module { "less module" :
-#   module  => "less-0.3",
-# require => Class["play"]
+#    module  => "less-0.3",
+#    require => Class["play"]
 #  }
 #
 #  play::service { "bilderverwaltung" :
-# path    => "/home/clement/demo/bilderverwaltung",
-# require => [Jdk6["Java6SDK"], Play::Module["mongodb module"]]
+#    path    => "/home/clement/demo/bilderverwaltung",
+#    require => [Jdk6["Java6SDK"], Play::Module["mongodb module"]]
 #  }
 #
 class play ($version, $install_path = "/opt", $user= "root") {
 
-include wget
+  include wget
 
-$play_path = "${install_path}/play-${version}"
-$download_url = "http://downloads.typesafe.com/play/${version}/play-${version}.zip"
+  $play_path = "${install_path}/play-${version}"
+  $download_url = "http://downloads.typesafe.com/play/${version}/play-${version}.zip"
 
-notice("Installing Play ${version}")
-wget::fetch {'download-play-framework':
-  source      => "$download_url",
-  destination => "/tmp/play-${version}.zip",
-  timeout     => 0,
-}
+  notice("Installing Play ${version}")
+  wget::fetch {'download-play-framework':
+    source      => "$download_url",
+    destination => "/tmp/play-${version}.zip",
+    timeout     => 0,
+  }
 
-exec { "mkdir.play.install.path":
-  command => "/bin/mkdir -p ${install_path}",
-  unless  => "/bin/bash [ -d ${install_path} ]"
-}
+  exec { "mkdir.play.install.path":
+    command => "/bin/mkdir -p ${install_path}",
+    unless  => "/bin/bash [ -d ${install_path} ]"
+  }
 
-exec {"unzip-play-framework":
-  cwd     => "${install_path}",
-  command => "/usr/bin/unzip /tmp/play-${version}.zip",
-  unless  => "/usr/bin/test -d $play_path",
-  require => [ Package["unzip"], Wget::Fetch["download-play-framework"], Exec["mkdir.play.install.path"] ],
-}
+  exec {"unzip-play-framework":
+    cwd     => "${install_path}",
+    command => "/usr/bin/unzip /tmp/play-${version}.zip",
+    unless  => "/usr/bin/test -d $play_path",
+    require => [ Package["unzip"], Wget::Fetch["download-play-framework"], Exec["mkdir.play.install.path"] ],
+  }
 
-exec { "change ownership of play installation":
-  cwd      => "${install_path}",
-  command  => "/bin/chown -R ${user}: play-${version}",
-  require  => Exec["unzip-play-framework"]
-}
+  exec { "change ownership of play installation":
+    cwd      => "${install_path}",
+    command  => "/bin/chown -R ${user}: play-${version}",
+    require  => Exec["unzip-play-framework"]
+  }
 
-file { "$play_path/play":
-  ensure  => file,
-  owner   => $user,
-  mode    => "0755",
-  require => [Exec["unzip-play-framework"]]
-}
+  file { "$play_path/play":
+    ensure  => file,
+    owner   => $user,
+    mode    => "0755",
+    require => [Exec["unzip-play-framework"]]
+  }
 
-file {'/usr/bin/play':
-  ensure  => 'link',
-  target  => "$play_path/play",
-  require => File["$play_path/play"],
-}
+  file {'/usr/bin/play':
+    ensure  => 'link',
+    target  => "$play_path/play",
+    require => File["$play_path/play"],
+  }
 
-# Add a unversioned symlink to the play installation.
-file { "${install_path}/play":
-  ensure => link,
-  target => $play_path,
-  require => Exec["mkdir.play.install.path", "unzip-play-framework"]
-}
+  # Add a unversioned symlink to the play installation.
+  file { "${install_path}/play":
+    ensure => link,
+    target => $play_path,
+    require => Exec["mkdir.play.install.path", "unzip-play-framework"]
+  }
 
-if !defined(Package['unzip']){ package{"unzip": ensure => installed} }
+  if !defined(Package['unzip']) {
+    package{ "unzip": ensure => installed }
+  }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,12 +16,12 @@
 # wget puppet module https://github.com/EslamElHusseiny/puppet-wget
 # A proper java installation and JAVA_HOME set
 # Sample Usage:
-#  class {'play': 
+#  class {'play':
 #    version => "2.1.4",
 #    user    => "appuser"
 #  }
 #  play::module {"mongodb module" :
-#   module  => "mongo-1.3", 
+#   module  => "mongo-1.3",
 # require => [Class["play"], Class["mongodb"]]
 #  }
 #
@@ -65,7 +65,6 @@ exec { "change ownership of play installation":
   cwd      => "${install_path}",
   command  => "/bin/chown -R ${user}: play-${version}",
   require  => Exec["unzip-play-framework"]
-
 }
 
 file { "$play_path/play":

--- a/manifests/module.pp
+++ b/manifests/module.pp
@@ -5,13 +5,13 @@
 #
 # == Parameters
 #
-# [*module*] 
+# [*module*]
 #  mandatory, the module name such as "less-0.3"
 #
 # == Examples
 #
 #  play::module {"mongodb module" :
-# 	module  => "mongo-1.3", 
+# 	module  => "mongo-1.3",
 #	require => [Class["play"], Class["mongodb"]]
 #  }
 #
@@ -23,8 +23,8 @@
 define play::module($module) {
 	include play
   	notice("Installing module ${module}")
-	exec { "install-play-module-${module}":                                                                                                                     
-      command => "yes | ${play::play_path}/play install ${module}", 
+	exec { "install-play-module-${module}":
+      command => "yes | ${play::play_path}/play install ${module}",
       unless  => "test -d ${play::play_path}/play/${module}"
   }
 }

--- a/manifests/module.pp
+++ b/manifests/module.pp
@@ -11,20 +11,20 @@
 # == Examples
 #
 #  play::module {"mongodb module" :
-# 	module  => "mongo-1.3",
-#	require => [Class["play"], Class["mongodb"]]
+#    module  => "mongo-1.3",
+#    require => [Class["play"], Class["mongodb"]]
 #  }
 #
 #  play::module { "less module" :
-# 	module  => "less-0.3",
-#	require => Class["play"]
+#    module  => "less-0.3",
+#    require => Class["play"]
 #  }
 #
 define play::module($module) {
-	include play
-  	notice("Installing module ${module}")
-	exec { "install-play-module-${module}":
-      command => "yes | ${play::play_path}/play install ${module}",
-      unless  => "test -d ${play::play_path}/play/${module}"
+  include play
+  notice("Installing module ${module}")
+  exec { "install-play-module-${module}":
+    command => "yes | ${play::play_path}/play install ${module}",
+    unless  => "test -d ${play::play_path}/play/${module}"
   }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -24,20 +24,20 @@
 # == Examples
 #
 #   play::service { "bilderverwaltung" :
-#	  path => "/home/clement/demo/bilderverwaltung",
+#     path => "/home/clement/demo/bilderverwaltung",
 #     group => "bilderverwaltung"
 #     user => "bilderverwaltung"
-#	  require => [Play::Module["mongodb module"]]
+#     require => [Play::Module["mongodb module"]]
 #   }
 #
 define play::service($path, $frameworkId = "", $javaOptions = "", $user = "root", $group = "root") {
-	include play
+  include play
 
-	# Make play_home accessible from the template
-	$play_home = $play::play_path
+  # Make play_home accessible from the template
+  $play_home = $play::play_path
 
-	file { "/etc/init/$title.conf":
-		content => template("play/play-upstart.erb"),
-		mode    => "0755",
-	}
+  file { "/etc/init/$title.conf":
+    content => template("play/play-upstart.erb"),
+    mode    => "0755",
+  }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,8 +1,8 @@
 # Resource: play::service
 # Represents a Play application started as a service using an upstart script.
 #
-# Launches Play application using a system service.
-# This resource creates an upstart script, but does not declare a Puppet service.
+# Launches Play application using a system service.  This resource creates an
+# upstart script, but does not declare a Puppet service.
 #
 # == Parameters
 #
@@ -30,14 +30,20 @@
 #     require => [Play::Module["mongodb module"]]
 #   }
 #
-define play::service($path, $frameworkId = "", $javaOptions = "", $user = "root", $group = "root") {
+define play::service(
+  $path,
+  $frameworkId = '',
+  $javaOptions = '',
+  $user = 'root',
+  $group = 'root'
+) {
   include play
 
   # Make play_home accessible from the template
   $play_home = $play::play_path
 
-  file { "/etc/init/$title.conf":
-    content => template("play/play-upstart.erb"),
-    mode    => "0755",
+  file { "/etc/init/${title}.conf":
+    content => template('play/play-upstart.erb'),
+    mode    => '0755',
   }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -6,7 +6,7 @@
 #
 # == Parameters
 #
-# [*path*] 
+# [*path*]
 #  mandatory, absolute path of the application.
 #
 # [*frameworkId*]
@@ -32,13 +32,12 @@
 #
 define play::service($path, $frameworkId = "", $javaOptions = "", $user = "root", $group = "root") {
 	include play
-	
+
 	# Make play_home accessible from the template
 	$play_home = $play::play_path
-	
+
 	file { "/etc/init/$title.conf":
 		content => template("play/play-upstart.erb"),
 		mode    => "0755",
 	}
-
 }


### PR DESCRIPTION
There were a lot of lines that ended in whitespace.  I have removed all
of these.

There were also a lot of lines that were only whitespace.  I have
removed all the whitespace on these lines as well.

Most files didn't end in a new line.  I have added new lines.

The second commit fixes the formatting to match the puppet style guidelines.  This includes using all spaces to indent.

The third commit fixes errors from puppet-lint.  These are mostly just using ' instead of " and making sure variables are written like ${var} instead of $var when in strings.  Also a couple 80+ character lines were changed to be shorter.
